### PR TITLE
fix: Reposition 'Clear All Markers' button on mobile

### DIFF
--- a/India/project/src/App.tsx
+++ b/India/project/src/App.tsx
@@ -51,6 +51,7 @@ function App() {
           activeMapElements={activeMapElements}
           onMapClick={handleMapClick}
           onMarkerRemove={handleMarkerRemove}
+          onClearAllMarkers={handleClearAllMarkers}
         />
       </div>
     </div>

--- a/India/project/src/components/MapComponent.tsx
+++ b/India/project/src/components/MapComponent.tsx
@@ -28,6 +28,7 @@ interface MapComponentProps {
   }>;
   onMapClick: (position: [number, number]) => void;
   onMarkerRemove: (markerId: string) => void;
+  onClearAllMarkers: () => void;
 }
 
 // This component handles map events
@@ -47,7 +48,8 @@ const MapComponent: React.FC<MapComponentProps> = ({
   selectedMissile,
   activeMapElements,
   onMapClick,
-  onMarkerRemove
+  onMarkerRemove,
+  onClearAllMarkers
 }) => {
   // India's centroid position
   const indiaPosition: [number, number] = [22.0, 79.0];
@@ -224,6 +226,15 @@ const MapComponent: React.FC<MapComponentProps> = ({
         ))}
         
         <MapLegend />
+
+        {/* Clear All Markers Button - Mobile Only */}
+        <button
+          onClick={onClearAllMarkers}
+          className="absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-red-600 hover:bg-red-700 text-white py-2 px-4 rounded font-medium z-[1000] md:hidden"
+          aria-label="Clear all markers"
+        >
+          Clear All Markers
+        </button>
       </MapContainer>
     </div>
   );

--- a/India/project/src/components/Sidebar.tsx
+++ b/India/project/src/components/Sidebar.tsx
@@ -142,7 +142,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         
         <button 
           onClick={onClearAllMarkers}
-          className="w-full bg-red-600 hover:bg-red-700 text-white py-3 px-4 rounded transition-colors duration-200 mt-4 font-medium flex items-center justify-center touch-manipulation"
+          className="w-full bg-red-600 hover:bg-red-700 text-white py-3 px-4 rounded transition-colors duration-200 mt-4 font-medium flex items-center justify-center touch-manipulation hidden md:flex"
         >
           Clear All Markers
         </button>


### PR DESCRIPTION
The 'Clear All Markers' button in the map view on mobile devices was overlapping with the map legend. This commit adjusts its position to the bottom-center of the map to resolve the overlap.